### PR TITLE
fix(60): Ensure large messages like encapsulated PDFs are not split and ignored by the server

### DIFF
--- a/__tests__/__utils__/index.ts
+++ b/__tests__/__utils__/index.ts
@@ -30,3 +30,17 @@ export const createDeferred = <T=any>(noUncaught?: boolean): Deferred<T> => {
   }
   return dfd
 }
+
+/** @internal */
+export const generateLargeBase64String = (sizeInKb: number = 200) => {
+  // Size in bytes (200KB = 200 * 1024 bytes)
+  const size = sizeInKb * 1024;
+
+  // Generate string of 'a' characters
+  let largeString = "";
+  for (let i = 0; i < size; i++) {
+    largeString += "a";
+  }
+
+  return Buffer.from(largeString).toString("base64");
+};

--- a/__tests__/hl7.end2end.test.ts
+++ b/__tests__/hl7.end2end.test.ts
@@ -298,6 +298,7 @@ describe('node hl7 end to end - client', () => {
         async (req, res) => {
           const messageReq = req.getMessage();
           expect(messageReq.get("MSH.12").toString()).toBe("2.7");
+          expect(messageReq.get("OBX.3.1").toString()).toBe("SOME-PDF");
           await res.sendResponse("AA");
           const messageRes = res.getAckMessage();
           expect(messageRes?.get("MSA.1").toString()).toBe("AA");

--- a/__tests__/hl7.end2end.test.ts
+++ b/__tests__/hl7.end2end.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { describe, expect, test } from 'vitest';
 import tcpPortUsed from 'tcp-port-used'
 import Client, {Batch, Message} from "node-hl7-client";
-import {createDeferred, expectEvent} from './__utils__'
+import {createDeferred, expectEvent, generateLargeBase64String} from './__utils__'
 import Server from "../src";
 
 describe('node hl7 end to end - client', () => {
@@ -288,4 +288,69 @@ describe('node hl7 end to end - client', () => {
 
   })
 
-})
+  describe("server/client large data checks", () => {
+    test("...large encapsulated data", async () => {
+      let dfd = createDeferred<void>();
+
+      const server = new Server({ bindAddress: "0.0.0.0" });
+      const listener = server.createInbound(
+        { port: 3000 },
+        async (req, res) => {
+          const messageReq = req.getMessage();
+          expect(messageReq.get("MSH.12").toString()).toBe("2.7");
+          await res.sendResponse("AA");
+          const messageRes = res.getAckMessage();
+          expect(messageRes?.get("MSA.1").toString()).toBe("AA");
+        }
+      );
+
+      await expectEvent(listener, "listen");
+
+      const client = new Client({ host: "0.0.0.0" });
+
+      const outbound = client.createConnection({ port: 3000 }, async (res) => {
+        const messageRes = res.getMessage();
+        expect(messageRes.get("MSA.1").toString()).toBe("AA");
+        dfd.resolve();
+      });
+
+      await expectEvent(outbound, "connect");
+
+      let message = new Message({
+        messageHeader: {
+          msh_9_1: "ADT",
+          msh_9_2: "A01",
+          msh_10: "CONTROL_ID",
+          msh_11_1: "D",
+        },
+      });
+
+      // Add Patient level observation result
+      const OBX = message.addSegment("OBX"); // Adds the OBX as a segment for this MSH.
+      OBX.set("1", "1"); // Sequence ID
+      OBX.set("2", "ED"); // Type Encapsulated Data
+      OBX.set("3.1", "SOME-PDF"); // Identifier (max 20 chars)
+      OBX.set("3.2", "Result Report"); // Title (max 199 chars)
+      OBX.set("3.3", "99COD"); // Some Coding System
+      OBX.set("5.2", "application"); // Type of referenced data
+      OBX.set("5.3", "pdf"); // Data Sub type
+      OBX.set("5.4", "Base64"); // PDF Data
+      OBX.set("5.5", generateLargeBase64String(300)); // PDF Data
+      OBX.set("8", "A"); // (A)bnormal or (N)ormal result
+      OBX.set("11", "F"); // Final result or correction to final result
+      OBX.set("14", "20240625103600"); // Result creation time
+
+      await outbound.sendMessage(message);
+
+      await dfd.promise;
+
+      expect(client.totalSent()).toEqual(1);
+      expect(client.totalAck()).toEqual(1);
+
+      await outbound.close();
+      await listener.close();
+
+      client.closeAll();
+    });
+  });
+});

--- a/src/server/inbound.ts
+++ b/src/server/inbound.ts
@@ -155,7 +155,7 @@ export class Inbound extends EventEmitter implements Inbound {
 
       try {
         // set message
-        loadedMessage = buffer.toString().replace(PROTOCOL_MLLP_HEADER, '')
+        loadedMessage += buffer.toString().replace(PROTOCOL_MLLP_HEADER, '')
 
         // is there is F5 and CR in this message?
         if (loadedMessage.includes(PROTOCOL_MLLP_FOOTER)) {


### PR DESCRIPTION
When a message includes a large data body, such as an encapsulated PDF (approx more than 200KB) the server chunks the message based on the socket buffer size, and treats each chunk individually. Only the last chunk is inspected for an MSH segment which it does not have. So the message is ignored and no response sent.

This fix addressed #60 and ensures the message parts are concatenated and successfully delivered. 